### PR TITLE
[mail_notifier] Router hostname in message subject

### DIFF
--- a/mail_notifier/notifier
+++ b/mail_notifier/notifier
@@ -21,33 +21,33 @@ mail_from=`uci get user_notify.smtp.from`
 lang="$(uci get -q foris.settings.lang || echo cs)" # Auto-detect from system configuration somehow?
 
 create_msmtp_config() {
-        local turris_smtp=`uci get user_notify.smtp.use_turris_smtp`
+	local turris_smtp=`uci get user_notify.smtp.use_turris_smtp`
 
 	echo "account notifier" > "$msmtp_cfg_file"
 	
-        if [ -n "$turris_smtp" ] && [ "$turris_smtp" = "1" ]; then
-           use_turris_smtp 
-        else
-            parse_user_server_setting
-        fi
+	if [ -n "$turris_smtp" ] && [ "$turris_smtp" = "1" ]; then
+	   use_turris_smtp 
+	else
+	    parse_user_server_setting
+	fi
 
 	echo "timeout 5" >> "$msmtp_cfg_file"
 	echo "account default: notifier" >> "$msmtp_cfg_file"
 }
 
 use_turris_smtp() {
-        mail_from="$(uci get user_notify.smtp.sender_name | cut -d '@' -f1)@notify.turris.cz"
-        local username=`atsha204cmd serial-number`
-        local password=`echo "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef" \
-                        | atsha204cmd challenge-response \
-                        | awk '{print tolower($0)}'`
+	mail_from="$(uci get user_notify.smtp.sender_name | cut -d '@' -f1)@notify.turris.cz"
+	local username=`atsha204cmd serial-number`
+	local password=`echo "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef" \
+			| atsha204cmd challenge-response \
+			| awk '{print tolower($0)}'`
 
-        local server="smtp.turris.cz"
-        local port="465"
+	local server="smtp.turris.cz"
+	local port="465"
 
-        echo "from $from" >> "$msmtp_cfg_file"
-        echo "host $server" >> "$msmtp_cfg_file"
-        echo "port $port" >> "$msmtp_cfg_file"
+	echo "from $from" >> "$msmtp_cfg_file"
+	echo "host $server" >> "$msmtp_cfg_file"
+	echo "port $port" >> "$msmtp_cfg_file"
 	echo "tls on" >> "$msmtp_cfg_file"
 	echo "tls_certcheck off" >> "$msmtp_cfg_file"
 	echo "tls_starttls off" >> "$msmtp_cfg_file"	  
@@ -64,8 +64,8 @@ parse_user_server_setting() {
 	local port=`uci get user_notify.smtp.port`
 	local security=`uci get user_notify.smtp.security`
 
-        echo "from $from" >> "$msmtp_cfg_file"
- 	echo "host $server" >> "$msmtp_cfg_file"
+	echo "from $from" >> "$msmtp_cfg_file"
+	echo "host $server" >> "$msmtp_cfg_file"
 	echo "port $port" >> "$msmtp_cfg_file"
 
 	if [ "$security" = "ssl" ]; then

--- a/mail_notifier/notifier
+++ b/mail_notifier/notifier
@@ -122,6 +122,12 @@ compose_message() {
 	local rand=`tr -dc A-Za-z0-9 < /dev/urandom 2>/dev/null | head -c8`
 	local domain=`uci get user_notify.smtp.from | cut -d '@' -f2`
 	local msg_id="<$date_time.$rand@$domain>"
+	local hostname=`cat /proc/sys/kernel/hostname`
+	if [ "$lang" = "cs" ]; then
+		local mail_subject="=?utf-8?Q?Upozorn=C4=9Bn=C3=AD?= od =?utf-8?Q?Va=C5=A1eho?= routeru $hostname"
+	else
+		local mail_subject="Notification from your router $hostname"
+	fi
 
 	local msg_list=`ls "$base_folder"`
 	for msg in $msg_list; do
@@ -201,7 +207,7 @@ compose_message() {
 		echo "Content-Type: text/plain; charset=UTF-8" >> "$msg_file"
 		echo "Date: $curr_date" >> "$msg_file"
 		echo "Message-ID: $msg_id" >> "$msg_file"
-		echo -e "Subject: =?utf-8?Q?Upozorn=C4=9Bn=C3=AD?= od =?utf-8?Q?Va=C5=A1eho?= routeru Turris\n" >> "$msg_file"
+		echo -e "Subject: $mail_subject\n" >> "$msg_file"
 		cat $msg_file.tmp >> "$msg_file"
 	fi
 

--- a/mail_notifier/notifier
+++ b/mail_notifier/notifier
@@ -18,7 +18,7 @@ mail_stamp="sent_by_email"
 smtp_enabled=`uci get user_notify.smtp.enable`
 mail_to=`uci get user_notify.smtp.to`
 mail_from=`uci get user_notify.smtp.from`
-lang="$(uci get -q foris.settings.lang | echo cs)" # Auto-detect from system configuration somehow?
+lang="$(uci get -q foris.settings.lang || echo cs)" # Auto-detect from system configuration somehow?
 
 create_msmtp_config() {
         local turris_smtp=`uci get user_notify.smtp.use_turris_smtp`


### PR DESCRIPTION
This adds router host name into the subject of e-mail notification, which is useful if someone has more than one Turris router. I've also fixed Czech-only message subject and the error in logic determining preferred notification language.
